### PR TITLE
fix(controls): use correct axis for xbox controller

### DIFF
--- a/src/main/kotlin/org/frc5183/constants/Controls.kt
+++ b/src/main/kotlin/org/frc5183/constants/Controls.kt
@@ -84,7 +84,7 @@ object Controls {
                 drive,
                 xInput = { DRIVER.leftX },
                 yInput = { DRIVER.leftY },
-                rotationInput = { DRIVER.rightX },
+                rotationInput = { DRIVER.getRawAxis(3) },
                 translationCurve =
                     MultiCurve(
                         listOf(


### PR DESCRIPTION
closes #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted teleop rotation control to use controller axis 3, improving consistency with standard controller mappings and ensuring expected steering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->