### PR TITLE
fix: use correct offset for front right swerve module

### DIFF
--- a/src/main/kotlin/org/frc5183/constants/swerve/modules/FrontRightSwerveModuleConstants.kt
+++ b/src/main/kotlin/org/frc5183/constants/swerve/modules/FrontRightSwerveModuleConstants.kt
@@ -20,7 +20,7 @@ object FrontRightSwerveModuleConstants : SwerveModuleConstants {
         CANCoderSwerve(13)
 
     override val ABSOLUTE_ENCODER_OFFSET: Angle =
-        Units.Degrees.of(74.004)
+        Units.Degrees.of(313.066)
 
     override val ABSOLUTE_ENCODER_INVERTED: Boolean =
         false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calibration for the front-right swerve module’s absolute encoder, fixing steering alignment drift. Improves wheel synchronization, odometry accuracy, and field-centric control, especially after startup. Enhances autonomous path tracking stability. No user action required; changes take effect on next deploy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->